### PR TITLE
Implement paste logging

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -129,6 +129,8 @@ app.get("*", (req, res) => {
 
 const transcriptDir = path.join(__dirname, "transcripts");
 if (!fs.existsSync(transcriptDir)) fs.mkdirSync(transcriptDir);
+const pasteDir = path.join(__dirname, "paste_logs");
+if (!fs.existsSync(pasteDir)) fs.mkdirSync(pasteDir);
 
 app.post("/api/save-transcript", async (req, res) => {
   try {
@@ -206,9 +208,12 @@ app.post("/api/store-paste-db", async (req, res) => {
         .json({ error: "Missing roomId, name, or pastedText" });
     }
 
-    await PasteLog.create({ roomId, name, pastedText });
+  await PasteLog.create({ roomId, name, pastedText });
 
-    res.status(200).json({ message: "Paste saved to DB" });
+    const filePath = path.join(pasteDir, `paste_room_${roomId}.txt`);
+    fs.appendFileSync(filePath, `[${name}] ${pastedText}\n`, "utf-8");
+
+  res.status(200).json({ message: "Paste saved to DB" });
   } catch (error) {
     console.error("Paste DB error:", error);
     res.status(500).json({ error: "Failed to save paste to DB" });

--- a/frontend/src/RoomPage.jsx
+++ b/frontend/src/RoomPage.jsx
@@ -24,7 +24,7 @@ const RoomPage = () => {
   const [isRecording, setIsRecording] = useState(false);
   const [transcript, setTranscript] = useState("");
   const [violationCount, setViolationCount] = useState(0);
-  const [clipboardLog] = useState([]);
+  const [clipboardLog, setClipboardLog] = useState([]);
 
   const localStreamRef = useRef(null);
   const remoteStreamRef = useRef(null);
@@ -127,6 +127,26 @@ const RoomPage = () => {
       };
     }
   }, [role, roomId]);
+
+  useEffect(() => {
+    if (role === "interviewee") {
+      const handlePaste = async (e) => {
+        const text = e.clipboardData.getData("text");
+        setClipboardLog((prev) => [...prev, text]);
+        try {
+          await axios.post("/api/store-paste-db", {
+            roomId,
+            name,
+            pastedText: text,
+          });
+        } catch (err) {
+          console.error("Failed to store pasted text:", err);
+        }
+      };
+      window.addEventListener("paste", handlePaste);
+      return () => window.removeEventListener("paste", handlePaste);
+    }
+  }, [role, roomId, name]);
 
   const handleViewClipboardLog = () => {
     const logText =


### PR DESCRIPTION
## Summary
- save each paste action for interviewees
- store paste events in backend text files

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684283f3c6dc8332b0c8322eb92ac25b